### PR TITLE
Requiring Sender DID

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -170,7 +170,7 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 
 	if runnerConfig.StackJSONPath == "" {
 		runnerConfig.Nodes = map[string]conf.Node{
-			"did:firefly:node/org": {
+			"did:firefly:node/node_0": {
 				DID:     "did:firefly:node/node_0",
 				URL:     "http://localhost:5000",
 				Name:    "node_0",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -161,6 +161,7 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 	runnerConfig.WebSocket = perfConfig.WSConfig
 	runnerConfig.Daemon = perfConfig.Daemon
 	runnerConfig.DelinquentAction = deliquentAction
+	runnerConfig.Sender = instance.Sender
 
 	err := validateConfig(*runnerConfig)
 	if err != nil {
@@ -168,14 +169,22 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 	}
 
 	if runnerConfig.StackJSONPath == "" {
-		runnerConfig.NodeURLs = []string{"http://localhost:5000"}
+		runnerConfig.Nodes = map[string]conf.Node{
+			"did:firefly:node/org": {
+				DID:     "did:firefly:node/node_0",
+				URL:     "http://localhost:5000",
+				Name:    "node_0",
+				OrgDID:  "did:firefly:org/org_0",
+				OrgName: "org_0",
+			},
+		}
 	} else {
 		stack, err := readStackJSON(runnerConfig.StackJSONPath)
 		if err != nil {
 			return nil, err
 		}
-		runnerConfig.NodeURLs = make([]string, len(stack.Members))
-		for i, member := range stack.Members {
+		runnerConfig.Nodes = make(map[string]conf.Node, len(stack.Members))
+		for _, member := range stack.Members {
 			if member.FireflyHostname == "" {
 				member.FireflyHostname = "localhost"
 			}
@@ -184,8 +193,17 @@ func generateRunnerConfigFromInstance(instance *conf.InstanceConfig, perfConfig 
 				scheme = "https"
 			}
 
-			// TODO support username / passwords ? ideally isn't embedded into the URL itself but set as a header
-			runnerConfig.NodeURLs[i] = fmt.Sprintf("%s://%s:%v", scheme, member.FireflyHostname, member.ExposedFireflyPort)
+			did := fmt.Sprintf("did:firefly:node/%s", member.NodeName)
+
+			runnerConfig.Nodes[did] = conf.Node{
+				DID:      did,
+				URL:      fmt.Sprintf("%s://%s:%v", scheme, member.FireflyHostname, member.ExposedFireflyPort),
+				Name:     member.NodeName,
+				OrgName:  member.OrgName,
+				OrgDID:   fmt.Sprintf("did:firefly:org/%s", member.OrgName),
+				Username: member.Username,
+				Password: member.Password,
+			}
 		}
 	}
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -69,8 +69,8 @@ type InstanceConfig struct {
 	Length           time.Duration   `yaml:"length" json:"length"`
 	MessageOptions   MessageOptions  `json:"messageOptions,omitempty" yaml:"messageOptions,omitempty"`
 	Sender           string          `json:"sender" yaml:"sender"`
-	Recipient        string          `json:"recipient" yaml:"recipient"`
-	RecipientAddress string          `json:"recipientAddress" yaml:"recipientAddress"`
+	Recipient        string          `json:"recipient,omitempty" yaml:"recipient,omitempty"`
+	RecipientAddress string          `json:"recipientAddress,omitempty" yaml:"recipientAddress,omitempty"`
 	TokenOptions     TokenOptions    `json:"tokenOptions,omitempty" yaml:"tokenOptions,omitempty"`
 	ContractOptions  ContractOptions `json:"contractOptions,omitempty" yaml:"contractOptions,omitempty"`
 	Workers          int             `json:"workers" yaml:"workers"`

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -49,10 +49,11 @@ type PerfRunnerConfig struct {
 	ContractOptions  ContractOptions
 	WebSocket        FireFlyWsConf
 	Workers          int
-	NodeURLs         []string
+	Nodes            map[string]Node
 	StackJSONPath    string
 	DelinquentAction string
 	Daemon           bool
+	Sender           string
 }
 
 type PerformanceTestConfig struct {
@@ -67,11 +68,22 @@ type InstanceConfig struct {
 	Test             fftypes.FFEnum  `yaml:"test" json:"test"`
 	Length           time.Duration   `yaml:"length" json:"length"`
 	MessageOptions   MessageOptions  `json:"messageOptions,omitempty" yaml:"messageOptions,omitempty"`
+	Sender           string          `json:"sender" yaml:"sender"`
 	Recipient        string          `json:"recipient" yaml:"recipient"`
 	RecipientAddress string          `json:"recipientAddress" yaml:"recipientAddress"`
 	TokenOptions     TokenOptions    `json:"tokenOptions,omitempty" yaml:"tokenOptions,omitempty"`
 	ContractOptions  ContractOptions `json:"contractOptions,omitempty" yaml:"contractOptions,omitempty"`
 	Workers          int             `json:"workers" yaml:"workers"`
+}
+
+type Node struct {
+	URL      string
+	DID      string
+	Name     string
+	OrgName  string
+	OrgDID   string
+	Username string
+	Password string
 }
 
 type FireFlyWsConf struct {

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -254,6 +254,8 @@ func (pr *perfRunner) Start() (err error) {
 
 perfLoop:
 	for pr.daemon || time.Now().Unix() < pr.endTime {
+		timeout := time.After(60 * time.Second)
+
 		select {
 		case <-signalCh:
 			break perfLoop
@@ -265,6 +267,12 @@ perfLoop:
 				}
 				lastCheckedTime = time.Now()
 			}
+			break
+		case <-timeout:
+			if pr.detectDeliquentMsgs() && pr.cfg.DelinquentAction == conf.DelinquentActionExit.String() {
+				break perfLoop
+			}
+			lastCheckedTime = time.Now()
 			break
 		}
 	}

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -56,6 +56,11 @@ var perfTestDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramO
 	Buckets:   []float64{0.5, 1.0, 2.0, 5.0, 10.0},
 }, []string{"test"})
 
+func init() {
+	prometheus.Register(deliquentMsgsCounter)
+	prometheus.Register(perfTestDurationHistogram)
+}
+
 type PerfRunner interface {
 	Init() error
 	Start() error

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -354,7 +354,7 @@ func (pr *perfRunner) eventLoop(wsconn wsclient.WSClient) (err error) {
 				}
 
 				pr.deleteMsgTime(event.Message.Header.ID.String())
-				log.Infof("\n\t%d - Received \n\t%d --- Event ID: %s\n\t%d --- Message ID: %s\n\t%d --- Data ID: %s", workerID, workerID, event.ID.String(), workerID, event.Message.Header.ID.String(), workerID, event.Message.Data[0].ID)
+				log.Infof("\n\t%d - Received from %s\n\t%d --- Event ID: %s\n\t%d --- Message ID: %s\n\t%d --- Data ID: %s", workerID, wsconn.URL(), workerID, event.ID.String(), workerID, event.Message.Header.ID.String(), workerID, event.Message.Data[0].ID)
 				if subInfo.Job == conf.PerfTestBlobBroadcast {
 					pr.downloadAndVerifyBlob(subInfo.NodeURL, event.Message.Data[0].ID.String(), *event.Message.Data[0].Hash)
 				}

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -118,6 +118,7 @@ func New(config *conf.PerfRunnerConfig) PerfRunner {
 		nodes:           config.Nodes,
 		subscriptionMap: make(map[string]SubscriptionInfo),
 		daemon:          config.Daemon,
+		sender:          config.Sender,
 	}
 }
 

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -422,7 +422,11 @@ func (pr *perfRunner) sendAndWait(req *resty.Request, nodeURL, ep string, id int
 				log.Infof("%d --> Sent blob: %s", id, msgRes.Header.ID)
 			}
 			// Wait for worker to confirm the message before proceeding to next task
-			for i := 0; i < len(pr.nodes); i++ {
+			confirmations := len(pr.nodes)
+			if action == conf.PerfTestBlobPrivateMsg.String() || action == conf.PerfTestPrivateMsg.String() {
+				confirmations = 2
+			}
+			for i := 0; i < confirmations; i++ {
 				select {
 				case <-pr.ctx.Done():
 					return nil

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -375,7 +375,7 @@ func (pr *perfRunner) sendAndWait(req *resty.Request, nodeURL, ep string, id int
 				"test": action,
 			})
 			if histErr != nil {
-				log.Errorf("Error retreiving histogram: %s", err)
+				log.Errorf("Error retreiving histogram: %s", histErr)
 			}
 			startTime := time.Now()
 

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -426,6 +426,7 @@ func (pr *perfRunner) sendAndWait(req *resty.Request, nodeURL, ep string, id int
 			if action == conf.PerfTestBlobPrivateMsg.String() || action == conf.PerfTestPrivateMsg.String() {
 				confirmations = 2
 			}
+
 			for i := 0; i < confirmations; i++ {
 				select {
 				case <-pr.ctx.Done():
@@ -434,9 +435,11 @@ func (pr *perfRunner) sendAndWait(req *resty.Request, nodeURL, ep string, id int
 					break
 				}
 			}
+
 			if histErr == nil {
 				hist.Observe(time.Since(startTime).Seconds())
 			}
+
 			log.Infof("%d <-- %s Finished", id, action)
 		case <-pr.ctx.Done():
 			return nil


### PR DESCRIPTION
Rather than an array of node URLs, we now maintain a map of node DIDs to structs containing node metadata.

Q: should the sender be an org DID instead?

More robust sender identity support i.e. `senderAddress` is saved for a follow up PR. This just enables selecting different nodes within a network for testing.